### PR TITLE
fix: use legacy ssl provider to run gatsby commands in Netlify node env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "gatsby develop",
-    "build": "gatsby build",
-    "serve": "gatsby serve",
-    "clean": "gatsby clean",
+    "build": "NODE_OPTIONS='--openssl-legacy-provider' gatsby build",
+    "serve": "NODE_OPTIONS='--openssl-legacy-provider' gatsby serve",
+    "clean": "NODE_OPTIONS='--openssl-legacy-provider' gatsby clean",
     "eslint": "eslint 'src/**/*.js' --max-warnings=0",
     "format": "prettier --write \"src/**/*.+(js|jsx|json|yml|yaml|css|md)\"",
     "semantic-release": "semantic-release",


### PR DESCRIPTION
## Purpose

Staring to see build failures on the Netlify side. The error is rather arcane:

```
3:26:20 PM: success onPostBootstrap - 0.000s
3:26:20 PM: ⠀
3:26:20 PM: info bootstrap finished - 2.613 s
3:26:20 PM: ⠀
3:26:21 PM: error UNHANDLED REJECTION error:0308010C:digital envelope routines::unsupported
3:26:21 PM: 
3:26:21 PM: 
3:26:21 PM:   Error: error:0308010C:digital envelope routines::unsupported
3:26:21 PM:   
```

A bit of research indicates it's an issue with how webpack running under Node v17+ does certain SSL things. A bit tough to diagnose exactly what's wrong with specific environment since Netlify's build environment is opaque, and apparently the error only crops up with certain installations of Node and not others. It cannot be reproduced locally, for example.

## Approach

StackOverflow and Netlify answers suggest that passing an `--legacy-ssl-providers` Node option helps circumvent the issue. So for now trying this.

## Reference

* https://answers.netlify.com/t/error-while-deploying-netlify/94592